### PR TITLE
update 040$f in the generated MARCXML to be 'homoit'

### DIFF
--- a/app/assets/xslt/homosaurus_xml.xsl
+++ b/app/assets/xslt/homosaurus_xml.xsl
@@ -46,13 +46,13 @@
           * for example; modify the below to use Ohio State would look like
           <datafield tag="040" ind1=" " ind2=" ">
              <subfield code="a">OSU</subfield>
-             <subfield code="f">homosaurus</subfield>
+             <subfield code="f">homoit</subfield>
              <subfield code="c">OSU</subfield>
           </datafield>
           *****************************************************************
       -->
       <datafield tag="040" ind1=" " ind2 = " ">
-        <subfield code="f">homosaurus</subfield>
+        <subfield code="f">homoit</subfield>
       </datafield>
 
 


### PR DESCRIPTION
This matches the code assigned to the vocabulary by the Library of Congress and should increase compatibility with MARC-based systems that use the 040$f to determine the thesaurus when matching authority records to headings in bib records.

Closes #31