### PR TITLE
Remove URI parentheses from term page

### DIFF
--- a/app/views/vocabulary/show.html.erb
+++ b/app/views/vocabulary/show.html.erb
@@ -10,7 +10,7 @@
   open_vr_dne = (VersionRelease.where(status: "Pending").pluck(:id) - @homosaurus_obj.edit_requests.where(status: "approved").pluck(:version_release_id)).count == 0
   editing_disabled = VersionRelease.where(status: "Pending").count == 0 || open_vr_dne || awaiting_deletion
   %>
-<h2><%= @homosaurus_obj.pref_label_localized.data %> (<%= @homosaurus_obj.get_relationship_at_version_release("uri", latest_vr_id) %>)</h2>
+<h2><%= @homosaurus_obj.pref_label_localized.data %> &ndash; <%= @homosaurus_obj.get_relationship_at_version_release("uri", latest_vr_id) %></h2>
 <% if @homosaurus_obj.visibility == "deleted" %>
   <div class="alert alert-danger" role="alert">
     This term has been removed from the vocabulary and is no longer in use.<br />


### PR DESCRIPTION
Remove parentheses around URIs on term pages and add an en dash for readability. Fixes #45 