### PR TITLE
Remove language from URI heading

### DIFF
--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -170,7 +170,7 @@ class Term < ActiveRecord::Base
       if rel_id == "identifier" 
         values = er.my_changes[rel_id]
       elsif rel_id == "uri"
-        values = er.my_changes[rel_id].sub('//', "//#{lang_id}.")
+        values = er.my_changes[rel_id]
       else
         er.my_changes[rel_id].each do |rc|
           rel_change = [rc[1], rc[2]]


### PR DESCRIPTION
Removing language from URI heading on term page. The URI with language was not stored in the database but added after-the-fact when generating the page.

This PR ensures that the displayed URI stays the same in all languages. Closes #52 
